### PR TITLE
Disable strict in bundles

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,7 @@ export default [
         input: 'javascript/mxClient.js',
         name: 'jjgraph',
         intro: 'var mxLoadResources, mxForceIncludes, mxResourceExtension, mxLoadStylesheets;',
+        useStrict: false,
         output: [
             { file: pkg.main, format: 'cjs' },
             { file: pkg.module, format: 'es' },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,7 @@ export default [
         input: 'javascript/mxClient.js',
         name: 'jjgraph',
         intro: 'var mxLoadResources, mxForceIncludes, mxResourceExtension, mxLoadStylesheets;',
-        useStrict: false,
+        strict: false,
         output: [
             { file: pkg.main, format: 'cjs' },
             { file: pkg.module, format: 'es' },


### PR DESCRIPTION
Because the code is not designed with strict in mind and rollup automatically adds "use strict;" at the top of generated bundles, we get all sorts of issues on runtime. One error i've encountered is in `mxCellRenderer.prototype.isTextShapeInvalid` where in function `check`, `result` is not defined in strict mode.

This PR just disables `use strict;` in rollup, as fixing the underlying code could add to many regressions.